### PR TITLE
added MPS support

### DIFF
--- a/src/hy2dl/utils/config.py
+++ b/src/hy2dl/utils/config.py
@@ -217,10 +217,17 @@ class Config(object):
             return device.lower()
 
         elif device.lower() == "gpu":
-            if not torch.cuda.is_available():
-                raise RuntimeError("CUDA requested but no CUDA devices available.")
+            if torch.cuda.is_available():
+                return "cuda:0"
+            elif torch.backends.mps.is_available():
+                return "mps"
+            else:
+                raise RuntimeError("GPU requested but no CUDA or MPS devices available.")
 
-            return "cuda:0"  # Default to the first CUDA device
+        elif device.lower() == "mps":
+            if not torch.backends.mps.is_available():
+                raise RuntimeError("MPS requested but not available.")
+            return "mps"
 
         elif device.lower().startswith("cuda"):
             if not torch.cuda.is_available():
@@ -241,7 +248,7 @@ class Config(object):
 
         else:
             print(
-                f"Invalid device specification: '{device}'. Expected 'cpu', 'gpu' or "
+                f"Invalid device specification: '{device}'. Expected 'cpu', 'gpu', 'mps' or "
                 f"'cuda[:<index>]'. CPU will be used by default."
             )
             return "cpu"


### PR DESCRIPTION
Hi Eduardo,

This little extension adds MPS support for the devices section of your config files. I wrapped it around your existing `'gpu'` option, so that existing behavior is not broken. It is implemented as a new option AND fallback if cuda is not available on a system. 
With this fix, it is possible to run the models on Apple's silicon GPUs. I only ran the LSTM_RainfallRunoff from the examples, but that worked without problems. The training performance with CPU was ~2 batches / s :) and improved to ~ 20 batches /s.
This can be helpful during testing and development on a local machine for Apple fan-boys like me, who always forget how to log into a HPC.